### PR TITLE
iterateOverNode(): fix optional parameters for PHP 8

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -228,7 +228,7 @@ class Html2Text {
 		return $nextName;
 	}
 
-	static function iterateOverNode($node, $prevName = null, $in_pre = false, $is_office_document = false, $options) {
+	static function iterateOverNode($node, $prevName, $in_pre, $is_office_document, $options) {
 		if ($node instanceof \DOMText) {
 		  // Replace whitespace characters with a space (equivilant to \s)
 			if ($in_pre) {


### PR DESCRIPTION
These parameters are not actually optional since they are followed by a
mandatory parameter.

This is deprecated by PHP 8:
https://www.php.net/manual/en/functions.arguments.php#example-156

cr_req 0
qa_req 0